### PR TITLE
Update install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ python3 -m venv --system-site-packages /opt/tooloop/control-center/venv
 
 # install site packages
 /opt/tooloop/control-center/venv/bin/pip install --upgrade pip
-/opt/tooloop/control-center/venv/bin/pip install Flask pexpect python-crontab zeroconf
+/opt/tooloop/control-center/venv/bin/pip install Flask==2.2.5 pexpect python-crontab zeroconf
 
 # publish services over Avahi/Bonjour
 cat > /etc/avahi/services/tooloop-control-center.service <<EOF


### PR DESCRIPTION
Use Flask version 2.2.5. From 2.3.0 and forward Flask has changes that break Tooloop-Control. Specifically the JSONEncoder was removed in 2.3.0, but other changes could also be affecting Tooloop-Control. See https://flask.palletsprojects.com/en/2.3.x/changes/